### PR TITLE
labAdmin: show devices available on the network

### DIFF
--- a/labAdmin/admin.py
+++ b/labAdmin/admin.py
@@ -14,6 +14,8 @@ from labAdmin.models import (
     UserProfile,
 )
 
+from .arp import get_neighbours
+
 
 class CardAdmin(admin.ModelAdmin):
     list_display = ('nfc_id', 'user', 'credits')
@@ -66,6 +68,22 @@ admin.site.register(Category, CategoryAdmin)
 class DeviceAdmin(admin.ModelAdmin):
     list_display = ('name', 'hourlyCost', 'category', 'mac', 'last_activity')
     ordering = ('name',)
+    change_form_template = 'labadmin/admin/device_change_form.html'
+    add_form_template = 'labadmin/admin/device_change_form.html'
+
+    def change_view(self, request, object_id, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['labadmin_available_devices'] = get_neighbours()
+        return super(DeviceAdmin, self).change_view(
+            request, object_id, form_url, extra_context=extra_context
+        )
+
+    def add_view(self, request, form_url='', extra_context=None):
+        extra_context = extra_context or {}
+        extra_context['labadmin_available_devices'] = get_neighbours()
+        return super(DeviceAdmin, self).add_view(
+            request, form_url, extra_context=extra_context
+        )
 
 admin.site.register(Device, DeviceAdmin)
 

--- a/labAdmin/arp.py
+++ b/labAdmin/arp.py
@@ -1,0 +1,20 @@
+IP_INDEX = 0
+MAC_INDEX = 3
+NUM_FIELDS = 6
+
+
+def get_neighbours():
+    """
+    Returns a generator of ip address, mac address tuples.
+    Empty mac addresses are filtered out.
+    """
+    with open('/proc/net/arp', 'r') as f:
+        # skip header
+        next(f)
+        for row in f:
+            fields = row.split()
+            if len(fields) < NUM_FIELDS:
+                continue
+            if fields[MAC_INDEX] == '00:00:00:00:00:00':
+                continue
+            yield fields[IP_INDEX], fields[MAC_INDEX]

--- a/labAdmin/templates/labadmin/admin/device_change_form.html
+++ b/labAdmin/templates/labadmin/admin/device_change_form.html
@@ -1,0 +1,43 @@
+{% extends "admin/change_form.html" %}
+{% load i18n admin_urls %}
+
+{% block object-tools %}
+{% if not is_popup %}
+  <ul class="object-tools">
+    {% block object-tools-items %}
+    {% if change %}
+    <li>
+        {% url opts|admin_urlname:'history' original.pk|admin_urlquote as history_url %}
+        <a href="{% add_preserved_filters history_url %}" class="historylink">{% trans "History" %}</a>
+    </li>
+    {% if has_absolute_url %}<li><a href="{{ absolute_url }}" class="viewsitelink">{% trans "View on site" %}</a></li>{% endif %}
+    {% endif %}
+	{% if labadmin_available_devices %}<li><a id="labadmin-available-devices-toggle" href="" class="viewsitelink">{% trans "Available Devices" %}</a></li>
+	<div id="labadmin-available-devices" style="display: none">
+		<table>
+		<tr>
+		<th>IP</th>
+		<th>MAC</th>
+		</tr>
+		{% for ip, mac in labadmin_available_devices %}
+		<tr>
+		<td>{{ ip }}</td>
+		<td>{{ mac }}</td>
+		</tr>
+		{% endfor %}
+		</table>
+	</div>
+	{% endif %}
+    {% endblock %}
+  </ul>
+{% endif %}
+{% endblock %}
+
+{% block admin_change_form_document_ready %}
+<script type="text/javascript">
+django.jQuery('#labadmin-available-devices-toggle').click(function(event) {
+    event.preventDefault();
+    django.jQuery('#labadmin-available-devices').toggle();
+});
+</script>
+{% endblock %}

--- a/labAdmin/tests.py
+++ b/labAdmin/tests.py
@@ -1,5 +1,8 @@
 import datetime
 import json
+import io
+
+from unittest.mock import mock_open, patch
 
 from django.contrib.auth.models import User
 from django.test import TestCase, Client, override_settings
@@ -13,6 +16,7 @@ from .models import (
     Card, Group, LogAccess, Role, TimeSlot, UserProfile,
     LogCredits, Category, Device, LogDevice, LogError
 )
+from .arp import get_neighbours
 
 
 class TestLabAdmin(TestCase):
@@ -518,3 +522,17 @@ class TimeSlotTests(TestCase):
         self.assertTrue(ts_now.exists())
         self.assertEqual(ts_now.count(), 1)
         self.assertEqual(ts_now.first().pk, open_ts.pk)
+
+
+class ArpTests(TestCase):
+    def test_read_neighbours(self):
+         data = io.StringIO('\n'.join([
+             'IP address       HW type     Flags       HW address            Mask     Device',
+             '10.120.0.124     0x1         0x2         55:54:00:4a:b0:35     *        wlan0',
+             '10.120.71.14     0x1         0x2         e4:2d:8c:5e:05:18     *',
+             '169.254.52.147   0x1         0x0         00:00:00:00:00:00     *        virbr0'
+         ]))
+         with patch('builtins.open', return_value=data, create=True) as m:
+             result = list(get_neighbours())
+
+         self.assertEqual(result, [('10.120.0.124', '55:54:00:4a:b0:35')])


### PR DESCRIPTION
When creating a new device in the admin show the list of devices
we have on our arp cache.
Visualization is a bit rough but works fine.

Fix #27